### PR TITLE
randomAuctions and only auctions name problem solved

### DIFF
--- a/back/DietiDeals24_25/src/main/java/com/dietideals/dietideals24_25/controllers/AuctionController.java
+++ b/back/DietiDeals24_25/src/main/java/com/dietideals/dietideals24_25/controllers/AuctionController.java
@@ -1,6 +1,7 @@
 package com.dietideals.dietideals24_25.controllers;
 
 import com.dietideals.dietideals24_25.domain.dto.AuctionDto;
+import com.dietideals.dietideals24_25.domain.dto.AuctionNameDto;
 import com.dietideals.dietideals24_25.domain.entities.AuctionEntity;
 import com.dietideals.dietideals24_25.mappers.Mapper;
 import com.dietideals.dietideals24_25.services.AuctionService;
@@ -54,8 +55,16 @@ public class AuctionController {
     }
 
     @GetMapping(path = "/auctions/item/{name}")
-    public List<AuctionDto> listAuctionsByItemName(@PathVariable("name") String itemName){
+    public List<AuctionNameDto> listAuctionsByItemName(@PathVariable("name") String itemName){
         List<AuctionEntity> auctions = auctionService.findByItemName(itemName);
+        return auctions.stream()
+                .map(auction -> new AuctionNameDto(auction.getId(), auction.getItem().getName()))
+                .collect(Collectors.toList());
+    }
+
+    @GetMapping(path = "/auctions/owner/{id}")
+    public List<AuctionDto> listRandomAuctions(@PathVariable("id") UUID ownerId){
+        List<AuctionEntity> auctions = auctionService.findRandomAuctions(ownerId);
         return auctions.stream()
                 .map(auctionMapper::mapTo)
                 .collect(Collectors.toList());

--- a/back/DietiDeals24_25/src/main/java/com/dietideals/dietideals24_25/domain/dto/AuctionDto.java
+++ b/back/DietiDeals24_25/src/main/java/com/dietideals/dietideals24_25/domain/dto/AuctionDto.java
@@ -24,7 +24,6 @@ public class AuctionDto {
 
     private UserEntity owner;
 
-
     private ItemEntity item;
 
     private ArrayList<BidEntity> bids = new ArrayList<>();

--- a/back/DietiDeals24_25/src/main/java/com/dietideals/dietideals24_25/domain/dto/AuctionNameDto.java
+++ b/back/DietiDeals24_25/src/main/java/com/dietideals/dietideals24_25/domain/dto/AuctionNameDto.java
@@ -1,0 +1,20 @@
+package com.dietideals.dietideals24_25.domain.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuctionNameDto {
+
+    private UUID id;
+
+    private String itemName;
+}

--- a/back/DietiDeals24_25/src/main/java/com/dietideals/dietideals24_25/repositories/AuctionRepository.java
+++ b/back/DietiDeals24_25/src/main/java/com/dietideals/dietideals24_25/repositories/AuctionRepository.java
@@ -1,6 +1,7 @@
 package com.dietideals.dietideals24_25.repositories;
 
 import com.dietideals.dietideals24_25.domain.entities.AuctionEntity;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -13,5 +14,8 @@ import java.util.UUID;
 public interface AuctionRepository extends CrudRepository<AuctionEntity, UUID> {
     @Query("SELECT a FROM auctions a WHERE lower(a.item.name) LIKE lower(concat('%', :itemName,'%'))") //TODO: check if works
     List<AuctionEntity> findByItemName(@Param("itemName") String itemName);
+
+    @Query("SELECT a FROM Auction a WHERE a.owner.uuid != :ownerUuid")
+    List<AuctionEntity> findRandomAuctions(@Param("ownerUuid") UUID ownerUuid, Pageable pageable);
 
 }

--- a/back/DietiDeals24_25/src/main/java/com/dietideals/dietideals24_25/services/AuctionService.java
+++ b/back/DietiDeals24_25/src/main/java/com/dietideals/dietideals24_25/services/AuctionService.java
@@ -12,6 +12,7 @@ public interface AuctionService {
     AuctionEntity save(AuctionEntity auctionEntity);
     Optional<AuctionEntity> findById(UUID id);
     List<AuctionEntity> findByItemName(String itemName);
+    List<AuctionEntity> findRandomAuctions(UUID ownerId);
     Boolean exists(UUID id);
     void delete(UUID id);
 }

--- a/back/DietiDeals24_25/src/main/java/com/dietideals/dietideals24_25/services/impl/AuctionServiceImpl.java
+++ b/back/DietiDeals24_25/src/main/java/com/dietideals/dietideals24_25/services/impl/AuctionServiceImpl.java
@@ -3,6 +3,8 @@ package com.dietideals.dietideals24_25.services.impl;
 import com.dietideals.dietideals24_25.domain.entities.AuctionEntity;
 import com.dietideals.dietideals24_25.repositories.AuctionRepository;
 import com.dietideals.dietideals24_25.services.AuctionService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -31,6 +33,12 @@ public class AuctionServiceImpl implements AuctionService {
     @Override
     public List<AuctionEntity> findByItemName(String itemName) {
         return auctionRepository.findByItemName(itemName);
+    }
+
+    @Override
+    public List<AuctionEntity> findRandomAuctions(UUID ownerId) {
+        PageRequest pageRequest = PageRequest.of(0, 4, Sort.by("uuid"));
+        return auctionRepository.findRandomAuctions(ownerId, pageRequest);
     }
 
     @Override


### PR DESCRIPTION
**Random Auctions Problem solved:**
A function has been added to AuctionRepository that implements an HQL query that takes all auctions that have a UUID different from the ID that is passed to the query, but only the top 4 auctions are passed based on the ordering of the UUIDs


**Only Auctions Name passed Problem solved:**
The findAuctionsByItemName function has been changed to return the type AuctionNameDto instead of AuctionDto, this new object only has the itemName (string) and the auction id (UUID) among the attributes, so that a list of auctions can be displayed and then only when you click on one of these is an API request made for that specific auction